### PR TITLE
add conc.py:_available_processor_count(); autopep8 conc.py

### DIFF
--- a/deco/conc.py
+++ b/deco/conc.py
@@ -3,17 +3,24 @@ import multiprocessing.reduction
 from multiprocessing import Process, Pipe, Queue, Pool
 from threading import Thread
 from itertools import izip
-import time, inspect, ast
-import marshal, types
+import time
+import inspect
+import ast
+import marshal
+import types
 from ast import NodeTransformer
 
+
 def concWrapper(args, global_args):
-        globals().update(global_args)
-        result = f(*args)
-        operations = [inner for outer in args if type(outer) is argProxy for inner in outer.operations]
-        return result, operations
+    globals().update(global_args)
+    result = f(*args)
+    operations = [inner for outer in args if type(
+        outer) is argProxy for inner in outer.operations]
+    return result, operations
+
 
 class argProxy(object):
+
     def __init__(self, arg_id, value):
         self.arg_id = arg_id
         self.operations = []
@@ -31,11 +38,14 @@ class argProxy(object):
     def __getitem__(self, key):
         return self.value.__getitem__(key)
 
+
 class SchedulerRewriter(NodeTransformer):
+
     def __init__(self, concurrent_funcs):
         self.arguments = []
         self.concurrent_funcs = concurrent_funcs
         self.encountered_funcs = set()
+
     def references_arg(self, node):
         for field in node._fields:
             value = getattr(node, field)
@@ -44,20 +54,25 @@ class SchedulerRewriter(NodeTransformer):
             if any([True for child in value if (type(child) is ast.Name and child.id in self.arguments)]):
                 return True
         return False
+
     @staticmethod
     def subscript_name(node):
         if type(node) is ast.Name:
             return node.id
         elif type(node) is ast.Subscript:
             return SchedulerRewriter.subscript_name(node.value)
-        raise ValueError("Assignment attempted on something that is not index based")
+        raise ValueError(
+            "Assignment attempted on something that is not index based")
+
     def is_valid_assignment(self, node):
         return type(node) is ast.Assign and type(node.value) is ast.Call \
             and type(node.value.func) is ast.Name and node.value.func.id in self.concurrent_funcs
+
     def generic_visit(self, node):
         super(NodeTransformer, self).generic_visit(node)
         if hasattr(node, 'body'):
-            returns = [i for i, child in enumerate(node.body) if type(child) is ast.Return]
+            returns = [i for i, child in enumerate(
+                node.body) if type(child) is ast.Return]
             if len(returns) > 0:
                 for wait in self.get_waits():
                     node.body.insert(returns[0], wait)
@@ -67,25 +82,31 @@ class SchedulerRewriter(NodeTransformer):
                     call = child.value
                     self.encountered_funcs.add(call.func.id)
                     name = child.targets[0].value
-                    self.arguments.append(SchedulerRewriter.subscript_name(name))
+                    self.arguments.append(
+                        SchedulerRewriter.subscript_name(name))
                     index = child.targets[0].slice.value
                     call.func = ast.Attribute(call.func, 'assign', ast.Load())
-                    call.args = [ast.Tuple([name, index], ast.Load())] + call.args
+                    call.args = [
+                        ast.Tuple([name, index], ast.Load())] + call.args
                     node.body[i] = ast.Expr(call)
                 elif self.references_arg(child):
                     inserts.insert(0, i)
             for index in inserts:
                 for wait in self.get_waits():
                     node.body.insert(index, wait)
+
     def get_waits(self):
         return [ast.Expr(ast.Call(ast.Attribute(ast.Name(fname, ast.Load()), 'wait', ast.Load()), [], [], None, None)) for fname in self.encountered_funcs]
+
     def visit_FunctionDef(self, node):
         node.decorator_list = []
         self.generic_visit(node)
         node.body += self.get_waits()
         return node
 
+
 class synchronized(object):
+
     def __init__(self, f):
         self.orig_f = f
         self.f = None
@@ -98,23 +119,27 @@ class synchronized(object):
             node = fast
             rewriter = SchedulerRewriter(concurrent.functions)
             rewriter.visit(node.body[0])
-            #print ast.dump(node.body[0])
+            # print ast.dump(node.body[0])
             ast.fix_missing_locations(node)
             out = compile(node, "<string>", "exec")
             exec out in self.orig_f.func_globals
             self.f = self.orig_f.func_globals[self.orig_f.__name__]
         return self.f(*args, **kwargs)
 
+
 class concurrent(object):
     params = ['processes']
     functions = []
+
     def __init__(self, *args, **kwargs):
-        self.processes = 3
+        self.processes = self._available_processor_count()
         if len(args) > 0 and type(args[0]) == types.FunctionType:
             self.setFunction(args[0])
         else:
-            self.__dict__.update({concurrent.params[i]: arg for i, arg in enumerate(args)})
-            self.__dict__.update({key: kwargs[key] for key in concurrent.params if key in kwargs})
+            self.__dict__.update(
+                {concurrent.params[i]: arg for i, arg in enumerate(args)})
+            self.__dict__.update(
+                {key: kwargs[key] for key in concurrent.params if key in kwargs})
         self.results = []
         self.assigns = []
         self.arg_proxies = {}
@@ -129,6 +154,7 @@ class concurrent(object):
 
     def setFunction(self, f):
         concurrent.functions.append(f.__name__)
+
         def findFreeNames(f):
             source = inspect.getsourcelines(f)
             source = "".join(source[0])
@@ -146,8 +172,10 @@ class concurrent(object):
         self.f = f
         globals()['f'] = f
         self.free_names = findFreeNames(f)
+
     def assign(self, target, *args):
         self.assigns.append((target, self(*args)))
+
     def __call__(self, *args):
         if len(args) > 0 and type(args[0]) == types.FunctionType:
             self.setFunction(args[0])
@@ -157,16 +185,20 @@ class concurrent(object):
         args = list(args)
         frm = inspect.stack()[1]
         mod = inspect.getmodule(frm[0])
-        global_arg_keys = [g for g in self.free_names if hasattr(mod, g) and type(getattr(mod, g)) != types.ModuleType]
+        global_arg_keys = [g for g in self.free_names if hasattr(
+            mod, g) and type(getattr(mod, g)) != types.ModuleType]
         global_args = [getattr(mod, g) for g in global_arg_keys]
         self.replaceWithProxies(args)
         self.replaceWithProxies(global_args)
-        result = self.p.apply_async(concWrapper, [args, dict(zip(global_arg_keys, global_args))])
+        result = self.p.apply_async(
+            concWrapper, [args, dict(zip(global_arg_keys, global_args))])
         self.results.append(result)
         return result
+
     def process_operation_queue(self, ops):
         for arg_id, key, value in ops:
             self.arg_proxies[arg_id].value.__setitem__(key, value)
+
     def wait(self):
         results = []
         while len(self.results) > 0:
@@ -177,3 +209,111 @@ class concurrent(object):
             assign[0][0][assign[0][1]] = assign[1].get()[0]
         self.arg_proxies = {}
         return results
+
+    @classmethod
+    def _available_processor_count():
+        """ Return the number of available virtual or physical CPUs on this system, 
+            via a variety of methods
+
+            Based on:
+              http://stackoverflow.com/a/1006301/2328433
+        """
+
+        # cpuset
+        # cpuset may restrict the number of *available* processors
+        try:
+            m = re.search(r'(?m)^Cpus_allowed:\s*(.*)$',
+                          open('/proc/self/status').read())
+            if m:
+                res = bin(int(m.group(1).replace(',', ''), 16)).count('1')
+                if res > 0:
+                    return res
+        except IOError:
+            pass
+
+        # for Python 2.6+
+        try:
+            return multiprocessing.cpu_count()
+        # on some systems cpu_count() may not be implemented
+        except NotImplementedError:
+            pass
+
+        # https://github.com/giampaolo/psutil
+        try:
+            import psutil
+            return psutil.cpu_count()
+        except (ImportError, AttributeError):
+            pass
+
+        # Windows
+        try:
+            proc_count = int(os.environ['NUMBER_OF_PROCESSORS'])
+
+            if proc_count > 0:
+                return proc_count
+        except (KeyError, ValueError):
+            pass
+
+        # jython
+        try:
+            from java.lang import Runtime
+            runtime = Runtime.getRuntime()
+            res = runtime.availableProcessors()
+            if res > 0:
+                return res
+        except ImportError:
+            pass
+
+        # BSD
+        try:
+            sysctl = subprocess.Popen(['sysctl', '-n', 'hw.ncpu'],
+                                      stdout=subprocess.PIPE)
+            scStdout = sysctl.communicate()[0]
+            res = int(scStdout)
+
+            if res > 0:
+                return res
+        except (OSError, ValueError):
+            pass
+
+        # Linux
+        try:
+            res = open('/proc/cpuinfo').read().count('processor\t:')
+
+            if res > 0:
+                return res
+        except IOError:
+            pass
+
+        # Solaris
+        try:
+            pseudoDevices = os.listdir('/devices/pseudo/')
+            res = 0
+            for pd in pseudoDevices:
+                if re.match(r'^cpuid@[0-9]+$', pd):
+                    res += 1
+
+            if res > 0:
+                return res
+        except OSError:
+            pass
+
+        # Other UNIXes (heuristic)
+        try:
+            try:
+                dmesg = open('/var/run/dmesg.boot').read()
+            except IOError:
+                dmesgProcess = subprocess.Popen(
+                    ['dmesg'], stdout=subprocess.PIPE)
+                dmesg = dmesgProcess.communicate()[0]
+
+            res = 0
+            while '\ncpu' + str(res) + ':' in dmesg:
+                res += 1
+
+            if res > 0:
+                return res
+        except OSError:
+            pass
+
+        return 3  # default value if all else fails


### PR DESCRIPTION
By default the process count was previously set to 3 unless overridden by setting the “processes” attribute of the concurrent-decorated function object. This adds a function, `_available_processor_count()`, to conc.py to determine the processor count via a variety of methods, and uses the new function to set the default number of processes. It should perhaps be n-1 to account for the spawning process.