### PR TITLE
PEP8 for deco

### DIFF
--- a/conc_test.py
+++ b/conc_test.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 
-import deco
 import time
+
+import deco
 
 
 @deco.concurrent

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@
 from distutils.core import setup
 
 setup(
-  name = "deco",
-  version = "0.4.1",
-  description = "A decorator for concurrency",
-  packages = ["deco"],
-  author='Alex Sherman',
-  author_email='asherman1024@gmail.com',
-  url='https://github.com/alex-sherman/deco')
+    name="deco",
+    version="0.4.1",
+    description="A decorator for concurrency",
+    packages=["deco"],
+    author='Alex Sherman',
+    author_email='asherman1024@gmail.com',
+    url='https://github.com/alex-sherman/deco')

--- a/test/testast.py
+++ b/test/testast.py
@@ -1,17 +1,19 @@
 import unittest
-import ast
-import inspect
+
 from deco import *
+
 
 @concurrent
 def conc_func(*args, **kwargs):
     pass
 
+
 @synchronized
 def body_cases():
     conc_func()
     a = True if False else False
-    b = (lambda : True)()
+    b = (lambda: True)()
+
 
 def indented():
     @synchronized
@@ -20,26 +22,28 @@ def indented():
 
     return _indented()
 
+
 @synchronized
 def subscript_args():
-    d = type('', (object,), {"items": {(0,0): 0}})()
+    d = type('', (object,), {"items": {(0, 0): 0}})()
     conc_func(d.items[0, 0])
-    #Read d to force a synchronization event
+    # Read d to force a synchronization event
     d = d
     return conc_func.in_progress
 
-class TestAST(unittest.TestCase):
 
-    #This just shouldn't throw any exceptions
+class TestAST(unittest.TestCase):
+    # This just shouldn't throw any exceptions
     def test_body_cases(self):
         body_cases()
 
-    #This just shouldn't throw any exceptions
+    # This just shouldn't throw any exceptions
     def test_indent_cases(self):
         indented()
 
     def test_subscript_args(self):
         self.assertFalse(subscript_args())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/testconc.py
+++ b/test/testconc.py
@@ -1,16 +1,18 @@
 import unittest
+
 from deco import *
 
+
 @concurrent
-def kwarg_func(kwarg = None):
+def kwarg_func(kwarg=None):
     kwarg[0] = "kwarged"
     return kwarg
 
-class TestAST(unittest.TestCase):
 
+class TestAST(unittest.TestCase):
     def test_kwargs(self):
         list_ = [0]
-        kwarg_func(kwarg = list_)
+        kwarg_func(kwarg=list_)
         kwarg_func.wait()
         self.assertEqual(list_[0], "kwarged")
 


### PR DESCRIPTION
Hey @alex-sherman,

This PR is related to following PEP8 conventions: 

- [Imports ordering](https://www.python.org/dev/peps/pep-0008/#imports). 
- [Blank Lines](https://www.python.org/dev/peps/pep-0008/#blank-lines). 
- Converting len(returns) > 0 to len(returns) because [Simple is better than complex](https://www.python.org/dev/peps/pep-0020/).
