### PR TITLE
pass along docstring and module information

### DIFF
--- a/deco/conc.py
+++ b/deco/conc.py
@@ -105,6 +105,8 @@ class concurrent(object):
     def setFunction(self, f):
         concurrent.functions[f.__name__] = f
         self.f_name = f.__name__
+        self.__doc__ = f.__doc__
+        self.__module__ = f.__module__
 
     def assign(self, target, *args, **kwargs):
         self.assigns.append((target, self(*args, **kwargs)))


### PR DESCRIPTION
This will allow for [sphinx](https://www.sphinx-doc.org/en/master/index.html) to document a function that is wrapped by `@concurrent`.  

Typically [it is recommended](https://github.com/sphinx-doc/sphinx/issues/3783#issuecomment-303099039) to use `functools.wraps` to implement this behavior, however, this is a simple approach with minimal changes to the current code structure.  If there is a better approach, please let me know.