### PR TITLE
Fix Python 3.9 ast compatibility.

### DIFF
--- a/deco/astutil.py
+++ b/deco/astutil.py
@@ -139,7 +139,10 @@ class SchedulerRewriter(NodeTransformer):
             self.encounter_call(call)
             name = node.targets[0].value
             self.arguments.add(SchedulerRewriter.top_level_name(name))
-            index = node.targets[0].slice.value
+            if hasattr(node.targets[0].slice, "value"):
+                index = node.targets[0].slice.value
+            else:
+                index = node.targets[0].slice
             call.func = ast.Attribute(call.func, 'assign', ast.Load())
             call.args = [ast.Tuple([name, index], ast.Load())] + call.args
             return copy_location(ast.Expr(call), node)

--- a/deco/astutil.py
+++ b/deco/astutil.py
@@ -139,9 +139,12 @@ class SchedulerRewriter(NodeTransformer):
             self.encounter_call(call)
             name = node.targets[0].value
             self.arguments.add(SchedulerRewriter.top_level_name(name))
+            # Check ast.slice compatibility
             if hasattr(node.targets[0].slice, "value"):
+                # For Python <= 3.8
                 index = node.targets[0].slice.value
             else:
+                # For Python == 3.9
                 index = node.targets[0].slice
             call.func = ast.Attribute(call.func, 'assign', ast.Load())
             call.args = [ast.Tuple([name, index], ast.Load())] + call.args


### PR DESCRIPTION
Since Python 3.9, ast.slice is no longer a ast.Slice() class, which
means ast.slice does not include the attribute "value".

This fix checks whether ast.slice has the "value" attribute and returns
the correct index.